### PR TITLE
Added the feature to allow for providing a widget that renders the chat user avatar

### DIFF
--- a/lib/src/models/chat/message_options.dart
+++ b/lib/src/models/chat/message_options.dart
@@ -65,12 +65,6 @@ class BubbleStyle {
   /// Shadow offset for message bubbles
   final Offset? shadowOffset;
 
-  /// Border for AI message bubble
-  final Border? aiBubbleBorder;
-
-  /// Border for user message bubble
-  final Border? userBubbleBorder;
-
   /// Widget for AI avatar image
   final Widget Function(ChatUser chatUser)? aiAvatarWidgetBuilder;
 
@@ -97,8 +91,6 @@ class BubbleStyle {
     this.shadowOpacity,
     this.shadowBlurRadius,
     this.shadowOffset,
-    this.aiBubbleBorder,
-    this.userBubbleBorder,
     this.aiAvatarWidgetBuilder,
     this.userAvatarWidgetBuilder,
   });

--- a/lib/src/models/chat/message_options.dart
+++ b/lib/src/models/chat/message_options.dart
@@ -130,6 +130,8 @@ class BubbleStyle {
     double? shadowOpacity,
     double? shadowBlurRadius,
     Offset? shadowOffset,
+    Widget Function(ChatUser)? aiAvatarWidgetBuilder,
+    Widget Function(ChatUser)? userAvatarWidgetBuilder,
   }) {
     return BubbleStyle(
       userBubbleMaxWidth: userBubbleMaxWidth ?? this.userBubbleMaxWidth,
@@ -155,6 +157,10 @@ class BubbleStyle {
       shadowOpacity: shadowOpacity ?? this.shadowOpacity,
       shadowBlurRadius: shadowBlurRadius ?? this.shadowBlurRadius,
       shadowOffset: shadowOffset ?? this.shadowOffset,
+      aiAvatarWidgetBuilder:
+          aiAvatarWidgetBuilder ?? this.aiAvatarWidgetBuilder,
+      userAvatarWidgetBuilder:
+          userAvatarWidgetBuilder ?? this.userAvatarWidgetBuilder,
     );
   }
 }

--- a/lib/src/models/chat/message_options.dart
+++ b/lib/src/models/chat/message_options.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen_ai_chat_ui/src/models/models.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 import '../ai_chat_config.dart';
@@ -64,6 +65,18 @@ class BubbleStyle {
   /// Shadow offset for message bubbles
   final Offset? shadowOffset;
 
+  /// Border for AI message bubble
+  final Border? aiBubbleBorder;
+
+  /// Border for user message bubble
+  final Border? userBubbleBorder;
+
+  /// Widget for AI avatar image
+  final Widget Function(ChatUser chatUser)? aiAvatarWidgetBuilder;
+
+  /// Widget for user avatar image
+  final Widget Function(ChatUser chatUser)? userAvatarWidgetBuilder;
+
   const BubbleStyle({
     this.userBubbleMaxWidth,
     this.aiBubbleMaxWidth,
@@ -84,6 +97,10 @@ class BubbleStyle {
     this.shadowOpacity,
     this.shadowBlurRadius,
     this.shadowOffset,
+    this.aiBubbleBorder,
+    this.userBubbleBorder,
+    this.aiAvatarWidgetBuilder,
+    this.userAvatarWidgetBuilder,
   });
 
   /// Default style for message bubbles

--- a/lib/src/widgets/custom_chat_widget.dart
+++ b/lib/src/widgets/custom_chat_widget.dart
@@ -495,6 +495,12 @@ class _CustomChatWidgetState extends State<CustomChatWidget> {
           ]
         : null;
 
+    // Avatar image builders
+    final aiAvatarWidgetBuilder =
+        widget.messageOptions.bubbleStyle?.aiAvatarWidgetBuilder;
+    final userAvatarWidgetBuilder =
+        widget.messageOptions.bubbleStyle?.userAvatarWidgetBuilder;
+
     // Create a custom decoration that prioritizes bubbleStyle colors
     BoxDecoration createBubbleDecoration() {
       if (effectiveDecoration != null) {
@@ -564,17 +570,13 @@ class _CustomChatWidgetState extends State<CustomChatWidget> {
                           child: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              // Add premium icon for AI messages
-                              if (!isUser)
-                                Padding(
-                                  padding: const EdgeInsets.only(right: 6),
-                                  child: Icon(
-                                    Icons.smart_toy_outlined,
-                                    size: 14,
-                                    color:
-                                        bubbleStyle.aiNameColor ?? primaryColor,
-                                  ),
-                                ),
+                              if (isUser &&
+                                  userAvatarWidgetBuilder != null) ...[
+                                userAvatarWidgetBuilder(message.user),
+                              ] else if (!isUser &&
+                                  aiAvatarWidgetBuilder != null) ...[
+                                aiAvatarWidgetBuilder(message.user),
+                              ],
                               Text(
                                 message.user.name,
                                 style: widget.messageOptions.userNameStyle ??


### PR DESCRIPTION
In the previous implementation, the ChatUser avatar was not being used. 

The user can now specify two new builders `aiAvatarWidgetBuilder` and `userAvatarWidgetBuilder`
which returns a widget to be rendered for the avatar image. 
The ChatUser is provided in the builder, which contains the avatar string set in 

```dart
 final _aiUser = ChatUser(
    id: 'ai',
    firstName: 'AI User',
    avatar: 'assets/images/icon.png',
  );
```
The builder can be specified in this way 
<img width="473" height="400" alt="image" src="https://github.com/user-attachments/assets/9793b24f-9f78-4a08-8b06-720bb46a8513" />

and shows up like this: 

<img width="596" height="386" alt="image" src="https://github.com/user-attachments/assets/15549675-388e-4e5b-a81d-3300ed7edd76" />
